### PR TITLE
Critical Fix: VIGL Scanner AttributeError

### DIFF
--- a/VIGL_Discovery_Complete.py
+++ b/VIGL_Discovery_Complete.py
@@ -767,7 +767,7 @@ if __name__ == "__main__":
                     "momentum": stock.price_momentum,
                     "breakoutStrength": stock.pattern_strength,
                     "sector": getattr(stock, 'sector', 'Technology'),
-                    "catalysts": stock.risk_factors,
+                    "catalysts": ["Volume spike", "Momentum pattern"] if stock.volume_spike_ratio > 10 else ["Pattern match"],
                     "similarity": stock.vigl_similarity,
                     "confidence": stock.confidence_score,
                     "isHighConfidence": stock.confidence_score >= 0.8,

--- a/vigl_background_worker.py
+++ b/vigl_background_worker.py
@@ -86,7 +86,7 @@ class VIGLDatabaseManager:
                     discovery.price_momentum,
                     discovery.vigl_similarity_score,  # Use correct field name
                     getattr(discovery, 'sector', 'Unknown'),
-                    discovery.risk_factors,
+                    json.dumps(["Volume spike", "Momentum pattern"] if discovery.volume_spike_ratio > 10 else ["Pattern match"]),
                     discovery.vigl_similarity_score,  # Use correct field name
                     discovery.confidence_level,  # Use correct field name
                     discovery.confidence_level >= 0.8,


### PR DESCRIPTION
## 🚨 Critical Bug Fix

### Problem
The VIGL scanner was failing with AttributeError when trying to access `risk_factors` attribute that doesn't exist on VIGLPatternStock objects.

### Error Message
```
AttributeError: 'VIGLPatternStock' object has no attribute 'risk_factors'
```

### Solution
- Replace `stock.risk_factors` with dynamically generated catalysts based on volume spike patterns
- Fixed in both VIGL_Discovery_Complete.py (line 770) and vigl_background_worker.py (line 89)
- Catalysts are now generated based on volume spike ratio:
  - If volume spike > 10x: ['Volume spike', 'Momentum pattern']
  - Otherwise: ['Pattern match']

### Files Changed
- `VIGL_Discovery_Complete.py`: Line 770
- `vigl_background_worker.py`: Line 89

### Testing
This fix will allow the VIGL scanner to run successfully without AttributeError.

### Urgency
**HIGH** - Production is currently broken. Please merge and deploy ASAP.